### PR TITLE
Update dependencies

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,25 +1,29 @@
 {
-  "name": "purescript-parsing-repetition",
-  "version": "0.0.6",
-  "license": "MIT",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/markfarrell/purescript-parsing-repetition.git"
-  },
-  "ignore": [
-    "**/.*",
-    "node_modules",
-    "bower_components",
-    "output"
-  ],
-  "dependencies": {
-    "purescript-prelude": "^4.1.1",
-    "purescript-console": "^4.4.0",
-    "purescript-effect": "^2.0.1",
-    "purescript-parsing": "^5.0.3",
-    "purescript-parsing-expect": "markfarrell/purescript-parsing-expect"
-  },
-  "devDependencies": {
-    "purescript-psci-support": "^4.0.0"
-  }
+    "name": "purescript-parsing-repetition",
+    "license": [
+        "MIT"
+    ],
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/markfarrell/purescript-parsing-repetition"
+    },
+    "ignore": [
+        "**/.*",
+        "node_modules",
+        "bower_components",
+        "output"
+    ],
+    "dependencies": {
+        "purescript-arrays": "^v6.0.1",
+        "purescript-effect": "^v3.0.0",
+        "purescript-foldable-traversable": "^v5.0.1",
+        "purescript-lists": "^v6.0.1",
+        "purescript-maybe": "^v5.0.0",
+        "purescript-parsing": "^v7.0.0",
+        "purescript-parsing-expect": "https://github.com/markfarrell/purescript-parsing-expect.git#v0.0.3",
+        "purescript-prelude": "^v5.0.1",
+        "purescript-psci-support": "^v5.0.0",
+        "purescript-strings": "^v5.0.0",
+        "purescript-tuples": "^v6.0.1"
+    }
 }

--- a/packages.dhall
+++ b/packages.dhall
@@ -116,10 +116,8 @@ let additions =
   }
 -------------------------------
 -}
-
-
 let upstream =
-      https://github.com/purescript/package-sets/releases/download/psc-0.13.8-20200831/packages.dhall sha256:cdb3529cac2cd8dd780f07c80fd907d5faceae7decfcaa11a12037df68812c83
+      https://github.com/purescript/package-sets/releases/download/psc-0.14.5-20211111/packages.dhall sha256:7ed6350fe897a93926d16298e37d2324aabbe5eca99810204719dc3632fb555f
 
 let overrides = {=}
 

--- a/spago.dhall
+++ b/spago.dhall
@@ -3,6 +3,7 @@ Welcome to a Spago project!
 You can edit this file as you like.
 -}
 { name = "parsing-repetition"
+, license = "MIT"
 , dependencies =
   [ "arrays"
   , "effect"

--- a/spago.dhall
+++ b/spago.dhall
@@ -4,6 +4,7 @@ You can edit this file as you like.
 -}
 { name = "parsing-repetition"
 , license = "MIT"
+, repository = "https://github.com/markfarrell/purescript-parsing-repetition"
 , dependencies =
   [ "arrays"
   , "effect"

--- a/spago.dhall
+++ b/spago.dhall
@@ -4,12 +4,17 @@ You can edit this file as you like.
 -}
 { name = "parsing-repetition"
 , dependencies =
-  [ "console"
+  [ "arrays"
   , "effect"
+  , "foldable-traversable"
+  , "lists"
+  , "maybe"
   , "parsing"
   , "parsing-expect"
   , "prelude"
   , "psci-support"
+  , "strings"
+  , "tuples"
   ]
 , packages = ./packages.dhall
 , sources = [ "src/**/*.purs", "test/**/*.purs" ]


### PR DESCRIPTION
This PR updates the dependencies and package set to the latest versions.

### Motivation

`parsing-repetition` is currently in the PureScript [package set](https://github.com/purescript/package-sets) and will need to have these dependency issues resolved in order to remain in the package set after the move to the new PureScript registry.

See https://github.com/purescript/registry/issues/250 for more details.